### PR TITLE
Fix node-red crashing when volume control used in flow

### DIFF
--- a/nodes/lgtv-volume.js
+++ b/nodes/lgtv-volume.js
@@ -16,7 +16,7 @@ module.exports = function (RED) {
 
             if (node._wireCount) {
                 node.tvConn.subscribe(node.id, 'ssap://audio/getVolume', (err, res) => {
-                    if (!err && res && res && res.changed.indexOf('volume') !== -1) {
+                    if (!err && res && res && res.changed && res.changed.indexOf('volume') !== -1) {
                         node.send({payload: res.volume});
                     }
                 });


### PR DESCRIPTION
When adding volume control node to a flow, node-red would crash because of a missing null check.

Fixes #45.